### PR TITLE
fix: Update Renovate workflow Node.js version and permissions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -18,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18" # Specify a Node.js version, adjust if needed
+          node-version: "20" # Updated Node.js version
 
       - name: Install Renovate CLI
         run: npm install -g renovate


### PR DESCRIPTION
- I've changed the Node.js version in the Renovate workflow from 18 to 20 to align with your project's Dockerfile.
- I've also added explicit `permissions` (contents: write, pull-requests: write) for the GITHUB_TOKEN used by the job. This is to address a potential issue where Renovate reported "No repositories found", ensuring it has the necessary rights to inspect your repository and manage pull requests.