### PR TITLE
Fix navigation logout issue in middleware authentication

### DIFF
--- a/__tests__/helpers/middleware.test.ts
+++ b/__tests__/helpers/middleware.test.ts
@@ -1,0 +1,165 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { middleware } from '../middleware'
+
+// Mock NextResponse.next() and NextResponse.redirect()
+jest.mock('next/server', () => ({
+  NextRequest: jest.fn(),
+  NextResponse: {
+    next: jest.fn(() => ({
+      headers: {
+        set: jest.fn(),
+      },
+    })),
+    redirect: jest.fn(),
+  },
+}))
+
+const mockNextResponse = NextResponse as jest.Mocked<typeof NextResponse>
+
+describe('Middleware Authentication', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const createMockRequest = (pathname: string, cookies: Record<string, string> = {}) => {
+    const mockCookies = new Map()
+    Object.entries(cookies).forEach(([key, value]) => {
+      mockCookies.set(key, { name: key, value })
+    })
+
+    return {
+      nextUrl: { pathname },
+      method: 'GET',
+      cookies: {
+        get: (name: string) => mockCookies.get(name),
+      },
+      url: `http://localhost:3000${pathname}`,
+    } as unknown as NextRequest
+  }
+
+  describe('Protected Routes', () => {
+    const protectedPaths = [
+      '/layout-admin',
+      '/layout',
+      '/screens',
+      '/slideshows',
+      '/slideshows-with-query',
+      '/slideshow',
+      '/preview',
+      '/users'
+    ]
+
+    protectedPaths.forEach(path => {
+      describe(`${path} route`, () => {
+        it('should redirect to login when no authentication cookies are present', () => {
+          const request = createMockRequest(path)
+          
+          middleware(request)
+
+          expect(mockNextResponse.redirect).toHaveBeenCalledWith(
+            expect.objectContaining({
+              href: expect.stringContaining('/login'),
+              searchParams: expect.objectContaining({
+                get: expect.any(Function)
+              })
+            })
+          )
+        })
+
+        it('should allow access when loggedIn cookie is true', () => {
+          const request = createMockRequest(path, { loggedIn: 'true' })
+          
+          const result = middleware(request)
+
+          expect(mockNextResponse.redirect).not.toHaveBeenCalled()
+          expect(mockNextResponse.next).toHaveBeenCalled()
+        })
+
+        it('should allow access when auth-token cookie is present', () => {
+          const request = createMockRequest(path, { 'auth-token': 'valid-jwt-token' })
+          
+          const result = middleware(request)
+
+          expect(mockNextResponse.redirect).not.toHaveBeenCalled()
+          expect(mockNextResponse.next).toHaveBeenCalled()
+        })
+
+        it('should redirect when loggedIn cookie is false', () => {
+          const request = createMockRequest(path, { loggedIn: 'false' })
+          
+          middleware(request)
+
+          expect(mockNextResponse.redirect).toHaveBeenCalled()
+        })
+
+        it('should allow access when both cookies are present', () => {
+          const request = createMockRequest(path, { 
+            loggedIn: 'true', 
+            'auth-token': 'valid-jwt-token' 
+          })
+          
+          const result = middleware(request)
+
+          expect(mockNextResponse.redirect).not.toHaveBeenCalled()
+          expect(mockNextResponse.next).toHaveBeenCalled()
+        })
+      })
+    })
+  })
+
+  describe('Unprotected Routes', () => {
+    const unprotectedPaths = [
+      '/',
+      '/login',
+      '/display/123',
+      '/api/auth/login',
+      '/_next/static/css/app.css',
+      '/favicon.ico'
+    ]
+
+    unprotectedPaths.forEach(path => {
+      it(`should allow access to ${path} without authentication`, () => {
+        const request = createMockRequest(path)
+        
+        const result = middleware(request)
+
+        expect(mockNextResponse.redirect).not.toHaveBeenCalled()
+        expect(mockNextResponse.next).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('CORS Headers', () => {
+    it('should add CORS headers to all responses', () => {
+      const request = createMockRequest('/')
+      const mockResponse = { headers: { set: jest.fn() } }
+      mockNextResponse.next.mockReturnValue(mockResponse)
+      
+      middleware(request)
+
+      expect(mockResponse.headers.set).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*')
+      expect(mockResponse.headers.set).toHaveBeenCalledWith(
+        'Access-Control-Allow-Methods',
+        'GET, POST, PUT, DELETE, OPTIONS'
+      )
+      expect(mockResponse.headers.set).toHaveBeenCalledWith(
+        'Access-Control-Allow-Headers',
+        'Origin, X-Requested-With, Content-Type, Accept, Authorization'
+      )
+    })
+  })
+
+  describe('OPTIONS Requests', () => {
+    it('should handle preflight OPTIONS requests', () => {
+      const request = createMockRequest('/screens')
+      request.method = 'OPTIONS'
+      
+      const result = middleware(request)
+
+      // Should return a Response with status 200, not redirect or call next()
+      expect(result).toBeInstanceOf(Response)
+      expect(mockNextResponse.redirect).not.toHaveBeenCalled()
+      expect(mockNextResponse.next).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/middleware.ts
+++ b/middleware.ts
@@ -20,16 +20,31 @@ export function middleware(request: NextRequest) {
   }
 
   // Check authentication for protected routes
-  const protectedPaths = ['/layout-admin', '/screens', '/slideshows']
+  const protectedPaths = [
+    '/layout-admin',
+    '/layout',
+    '/screens',
+    '/slideshows',
+    '/slideshows-with-query',
+    '/slideshow',
+    '/preview',
+    '/users'
+  ]
   const isProtectedPath = protectedPaths.some((path) =>
     request.nextUrl.pathname.startsWith(path)
   )
 
   if (isProtectedPath) {
-    // Check for authentication cookie or session
-    const sessionCookie = request.cookies.get('sessionId')
+    // Check for authentication cookies from both auth systems
+    const loggedInCookie = request.cookies.get('loggedIn')
+    const authTokenCookie = request.cookies.get('auth-token')
 
-    if (!sessionCookie) {
+    // User is authenticated if either cookie exists and is valid
+    const isAuthenticated =
+      (loggedInCookie && loggedInCookie.value === 'true') ||
+      (authTokenCookie && authTokenCookie.value)
+
+    if (!isAuthenticated) {
       // Redirect to login if not authenticated
       const loginUrl = new URL('/login', request.url)
       loginUrl.searchParams.set('redirect', request.nextUrl.pathname)


### PR DESCRIPTION
## Problem

After successfully logging in, clicking on "Screens" or "Slideshows" menu items in the sidebar caused the application to unexpectedly log users out and redirect them to the login screen instead of navigating to the respective pages.

## Root Cause

The issue was caused by a **cookie mismatch** between two authentication systems running in parallel:

1. **Pages Router Authentication** (`helpers/auth.tsx`): Sets a `loggedIn` cookie
2. **App Router Authentication** (`lib/auth.ts`): Sets an `auth-token` cookie  
3. **Middleware** (`middleware.ts`): Was incorrectly checking for a `sessionId` cookie that neither system actually sets

### Problem Flow
1. User logs in successfully → `loggedIn` cookie is set
2. User clicks "Screens" or "Slideshows" in sidebar → Navigation request is made
3. Middleware intercepts the request → Looks for `sessionId` cookie (doesn't exist)
4. Middleware redirects to `/login` → User appears to be "logged out"

## Solution

### 🔧 Fixed Authentication Cookie Check
Updated `middleware.ts` to properly check for both authentication cookies:

```typescript
// Check for authentication cookies from both auth systems
const loggedInCookie = request.cookies.get('loggedIn')
const authTokenCookie = request.cookies.get('auth-token')

// User is authenticated if either cookie exists and is valid
const isAuthenticated =
  (loggedInCookie && loggedInCookie.value === 'true') ||
  (authTokenCookie && authTokenCookie.value)
```

### 📋 Updated Protected Paths
Added comprehensive list of all pages that use the `protect()` HOC:

```typescript
const protectedPaths = [
  '/layout-admin',
  '/layout',
  '/screens',
  '/slideshows',
  '/slideshows-with-query',
  '/slideshow',
  '/preview',
  '/users'
]
```

### 🧪 Added Tests
Created comprehensive middleware tests to verify authentication logic and prevent regression.

## Testing

To verify the fix:

1. ✅ Log in to the application
2. ✅ Navigate to "Screens" from the sidebar - should stay logged in
3. ✅ Navigate to "Slideshows" from the sidebar - should stay logged in
4. ✅ Try other protected routes - all should work without unexpected logouts

## Impact

✅ **Fixes the immediate issue**: Navigation to `/screens` and `/slideshows` no longer causes unexpected logouts  
✅ **Maintains backward compatibility**: Both authentication systems continue to work  
✅ **Comprehensive protection**: All protected routes are now properly secured  
✅ **Future-proof**: The middleware now handles both cookie types

## Files Changed

- `middleware.ts` - Fixed authentication cookie checking logic
- `__tests__/helpers/middleware.test.ts` - Added comprehensive test coverage

## Related Issues

Resolves the navigation logout issue described in the original problem statement.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author